### PR TITLE
Add callback to fs.close

### DIFF
--- a/pi-blaster.js
+++ b/pi-blaster.js
@@ -21,7 +21,9 @@ function writeCommand(cmd, callback) {
 				if (error) {
 					if (callback && typeof callback == 'function') {callback(error)};
 				} else {
-					fs.close(fd);
+					fs.close(fd, function (err) {
+						if (err) callback (err);
+					});
 					if (callback && typeof callback == 'function') {callback()};
 				}
 			});


### PR DESCRIPTION
Warning on pi-blaster.setPwm() function:
DeprecationWarning: Calling an asynchronous function without callback is deprecated

According to fs docs callback should be used.
https://nodejs.org/api/fs.html#fs_fs_close_fd_callback